### PR TITLE
Endpoints for. manage accounts and viper for env variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@
 # Environment files
 .env
 .env.*
+app.env
 
 # Mac system files
 .DS_Store

--- a/api/account.go
+++ b/api/account.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+
+	db "github.com/devspace/simplebank/db/sqlc"
+	"github.com/gin-gonic/gin"
+)
+
+type createAccountRequest struct {
+	Owner    string `json:"owner" binding:"required"`
+	Currency string `json:"currency" binding:"required,oneof=USD EUR"`
+}
+
+func (server *Server) createAccount(ctx *gin.Context) {
+	var req createAccountRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, errorResponse(err))
+	}
+
+	arg := db.CreateAccountParams{
+		Owner:    req.Owner,
+		Currency: req.Currency,
+		Balance:  0,
+	}
+
+	account, err := server.store.CreateAccount(ctx, arg)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, account)
+
+}
+
+type getAccountRequest struct {
+	ID int64 `uri:"id" binding:"required,min=1"`
+}
+
+func (server *Server) getAccount(ctx *gin.Context) {
+	var req getAccountRequest
+	if err := ctx.ShouldBindUri(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, errorResponse(err))
+		return
+	}
+
+	account, err := server.store.GetAccount(ctx, req.ID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			ctx.JSON(http.StatusNotFound, errorResponse(err))
+			return
+		}
+		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, account)
+}
+
+type listAccountsRequest struct {
+	PageID   int32 `form:"page_id" binding:"required,min=1"`
+	PageSize int32 `form:"page_size" binding:"required,min=1,max=10"`
+}
+
+func (server *Server) listAccounts(ctx *gin.Context) {
+	var req listAccountsRequest
+	if err := ctx.ShouldBindQuery(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, errorResponse(err))
+		return
+	}
+
+	arg := db.ListAccountsParams{
+		Limit:  req.PageSize,
+		Offset: (req.PageID - 1) * req.PageSize,
+	}
+
+	accounts, err := server.store.ListAccounts(ctx, arg)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, accounts)
+
+}

--- a/api/server.go
+++ b/api/server.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	db "github.com/devspace/simplebank/db/sqlc"
+	"github.com/gin-gonic/gin"
+)
+
+// Server struct represents the HTTP server and contains the store and router
+type Server struct {
+	store  *db.Store
+	router *gin.Engine
+}
+
+// Setup a new HTTP server and set up routing
+func NewServer(store *db.Store) *Server {
+	server := &Server{store: store}
+	router := gin.Default()
+	router.POST("/accounts", server.createAccount)
+	router.GET("/accounts/:id", server.getAccount)
+	router.GET("/accounts", server.listAccounts)
+
+	server.router = router
+	return server
+}
+
+// Start the HTTP server on the specified address
+func (server *Server) Start(address string) error {
+	return server.router.Run(address)
+}
+
+func errorResponse(err error) gin.H {
+	return gin.H{"error": err.Error()}
+}

--- a/db/sqlc/account.sql.go
+++ b/db/sqlc/account.sql.go
@@ -127,7 +127,7 @@ func (q *Queries) ListAccounts(ctx context.Context, arg ListAccountsParams) ([]A
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Account
+	items := []Account{}
 	for rows.Next() {
 		var i Account
 		if err := rows.Scan(

--- a/db/sqlc/entry.sql.go
+++ b/db/sqlc/entry.sql.go
@@ -72,7 +72,7 @@ func (q *Queries) ListEntries(ctx context.Context, arg ListEntriesParams) ([]Ent
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Entry
+	items := []Entry{}
 	for rows.Next() {
 		var i Entry
 		if err := rows.Scan(

--- a/db/sqlc/main_test.go
+++ b/db/sqlc/main_test.go
@@ -6,20 +6,20 @@ import (
 	"os"
 	"testing"
 
+	"github.com/devspace/simplebank/util"
 	_ "github.com/lib/pq"
-)
-
-const (
-	dbDriver = "postgres"
-	dbSource = "postgresql://myuser:mysecretpassword@localhost:5432/simple_bank?sslmode=disable"
 )
 
 var testQueries *Queries
 var testDB *sql.DB
 
 func TestMain(m *testing.M) {
-	var err error
-	testDB, err = sql.Open(dbDriver, dbSource)
+	config, err := util.LoadConfig("../..")
+	if err != nil {
+		log.Fatal("cannot load config:", err)
+	}
+
+	testDB, err = sql.Open(config.DBDriver, config.DBSource)
 	if err != nil {
 		log.Fatal("cannot connect to db:", err)
 	}

--- a/db/sqlc/transfer.sql.go
+++ b/db/sqlc/transfer.sql.go
@@ -83,7 +83,7 @@ func (q *Queries) ListTransfers(ctx context.Context, arg ListTransfersParams) ([
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Transfer
+	items := []Transfer{}
 	for rows.Next() {
 		var i Transfer
 		if err := rows.Scan(

--- a/go.mod
+++ b/go.mod
@@ -12,11 +12,13 @@ require (
 	github.com/bytedance/sonic v1.14.1 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.10 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.27.0 // indirect
+	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.18.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -28,9 +30,17 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.1 // indirect
+	github.com/sagikazarmark/locafero v0.11.0 // indirect
+	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
+	github.com/spf13/afero v1.15.0 // indirect
+	github.com/spf13/cast v1.10.0 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/spf13/viper v1.21.0 // indirect
+	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.0 // indirect
 	go.uber.org/mock v0.6.0 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.21.0 // indirect
 	golang.org/x/crypto v0.42.0 // indirect
 	golang.org/x/mod v0.28.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,43 @@ require (
 )
 
 require (
+	github.com/bytedance/gopkg v0.1.3 // indirect
+	github.com/bytedance/sonic v1.14.1 // indirect
+	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.10 // indirect
+	github.com/gin-contrib/sse v1.1.0 // indirect
+	github.com/go-playground/locales v0.14.1 // indirect
+	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-playground/validator/v10 v10.27.0 // indirect
+	github.com/goccy/go-json v0.10.5 // indirect
+	github.com/goccy/go-yaml v1.18.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/quic-go/qpack v0.5.1 // indirect
+	github.com/quic-go/quic-go v0.54.1 // indirect
+	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+	github.com/ugorji/go/codec v1.3.0 // indirect
+	go.uber.org/mock v0.6.0 // indirect
+	golang.org/x/arch v0.21.0 // indirect
+	golang.org/x/crypto v0.42.0 // indirect
+	golang.org/x/mod v0.28.0 // indirect
+	golang.org/x/net v0.44.0 // indirect
+	golang.org/x/sync v0.17.0 // indirect
+	golang.org/x/sys v0.36.0 // indirect
+	golang.org/x/text v0.29.0 // indirect
+	golang.org/x/tools v0.37.0 // indirect
+	google.golang.org/protobuf v1.36.9 // indirect
+)
+
+require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gin-gonic/gin v1.11.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"database/sql"
+	"log"
+
+	"github.com/devspace/simplebank/api"
+	db "github.com/devspace/simplebank/db/sqlc"
+	_ "github.com/lib/pq"
+)
+
+const (
+	dbDriver = "postgres"
+	dbSource = "postgresql://myuser:mysecretpassword@localhost:5432/simple_bank?sslmode=disable"
+	address  = "0.0.0.0:8080"
+)
+
+func main() {
+	conn, err := sql.Open(dbDriver, dbSource)
+	if err != nil {
+		log.Fatal("cannot connect to db:", err)
+	}
+
+	store := db.NewStore(conn)
+	server := api.NewServer(store)
+	err = server.Start(address)
+	if err != nil {
+		log.Fatal("cannot start server:", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -6,24 +6,24 @@ import (
 
 	"github.com/devspace/simplebank/api"
 	db "github.com/devspace/simplebank/db/sqlc"
+	"github.com/devspace/simplebank/util"
 	_ "github.com/lib/pq"
 )
 
-const (
-	dbDriver = "postgres"
-	dbSource = "postgresql://myuser:mysecretpassword@localhost:5432/simple_bank?sslmode=disable"
-	address  = "0.0.0.0:8080"
-)
-
 func main() {
-	conn, err := sql.Open(dbDriver, dbSource)
+	config, err := util.LoadConfig(".")
+	if err != nil {
+		log.Fatal("cannot load config:", err)
+	}
+
+	conn, err := sql.Open(config.DBDriver, config.DBSource)
 	if err != nil {
 		log.Fatal("cannot connect to db:", err)
 	}
 
 	store := db.NewStore(conn)
 	server := api.NewServer(store)
-	err = server.Start(address)
+	err = server.Start(config.ServerAddress)
 	if err != nil {
 		log.Fatal("cannot start server:", err)
 	}

--- a/makefile
+++ b/makefile
@@ -12,5 +12,6 @@ sqlc:
 	sqlc generate
 test:
 	go test -v -cover ./...
-
-.PHONY: postgres createdb dropdb migrateup migratedown sqlc test
+server:
+	go run main.go
+.PHONY: postgres createdb dropdb migrateup migratedown sqlc test server

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -11,6 +11,7 @@ sql:
         emit_prepared_queries: true
         emit_exact_table_names: false
         emit_interface: false
+        emit_empty_slices: true
 overrides: {}
 plugins: []
 rules: []

--- a/util/config.go
+++ b/util/config.go
@@ -1,0 +1,28 @@
+package util
+
+import "github.com/spf13/viper"
+
+// Config stores all configuration of the application
+// The vales are read by viper from a config file or environment variables
+type Config struct {
+	DBDriver      string `mapstructure:"DB_DRIVER"`
+	DBSource      string `mapstructure:"DB_SOURCE"`
+	ServerAddress string `mapstructure:"SERVER_ADDRESS"`
+}
+
+// LoadConfig reads configuration from file or environment variables.
+func LoadConfig(path string) (config Config, err error) {
+	viper.AddConfigPath(path)
+	viper.SetConfigName("app")
+	viper.SetConfigType("env") // could be json, toml, yaml, yml, properties, props, prop, dotenv
+
+	viper.AutomaticEnv()
+
+	err = viper.ReadInConfig()
+	if err != nil {
+		return
+	}
+
+	err = viper.Unmarshal(&config)
+	return
+}


### PR DESCRIPTION
This pull request introduces a RESTful API server for account management in the banking application, using Gin for routing and Viper for configuration. It adds handlers for creating, retrieving, and listing accounts, integrates configuration loading, and updates the codebase to improve slice handling and test configuration. The changes also include dependency updates and a new server startup target in the makefile.

**API Server Implementation:**
* Added a new Gin-based HTTP server in `api/server.go`, with endpoints for creating, retrieving, and listing accounts. The server uses a `db.Store` for database operations and includes error handling helpers.
* Implemented account-related handlers in `api/account.go`, including request validation and pagination support for listing accounts.

**Configuration Management:**
* Introduced `util/config.go` to load application configuration using Viper, supporting environment variables and `.env` files.
* Updated `main.go` to use the new configuration loader, and refactored database connection setup to use loaded config values.
* Refactored test setup in `db/sqlc/main_test.go` to use configuration from Viper for database connection.

**Code Generation and Slice Handling:**
* Enabled `emit_empty_slices` in `sqlc.yaml` to ensure generated query methods return empty slices instead of nil.
* Updated generated query methods in `db/sqlc/account.sql.go`, `db/sqlc/entry.sql.go`, and `db/sqlc/transfer.sql.go` to use empty slice initialization for results. [[1]](diffhunk://#diff-a9b87aa6a2d0f35438f44cb4e75289164417b972663246f3e0269813037883bbL130-R130) [[2]](diffhunk://#diff-79214bee8c6820493789693daea1963fa61ca6c5b3f97ef3a9a195e5fc2fac0eL75-R75) [[3]](diffhunk://#diff-85fa586105f8cdef03d4176c69be6850891cdf17e3434b888b8345c6cf4971b0L86-R86)

**Dependency Management:**
* Added Gin and related indirect dependencies in `go.mod` to support the new API server and configuration management.

**Build and Run Improvements:**
* Added a `server` target to the `makefile` to simplify starting the API server.